### PR TITLE
Revert change to the way the environment variables are loaded

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -11,21 +11,7 @@ export class DBService {
   constructor() {
     // Init admin
     try {
-      const serviceAccount = {
-        type: process.env.type,
-        projectId: process.env.project_id,
-        privateKey: process.env.private_key.replace(/\\n/g, '\n'),
-        project_id: process.env.project_id,
-        private_key_id: process.env.private_key_id.replace(/\\n/g, '\n'),
-        private_key: process.env.private_key,
-        client_email: process.env.client_email,
-        client_id: process.env.client_id,
-        auth_uri: process.env.auth_uri,
-        token_uri: process.env.token_uri,
-        auth_provider_x509_cert_url: process.env.auth_provider_x509_cert_url,
-        client_x509_cert_url: process.env.client_x509_cert_url
-      };
-      //require('../../keys/keys.json');
+      const serviceAccount = require('../../keys/keys.json');
 
       admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),


### PR DESCRIPTION
Loading was replaced by environment variables for testing but was not reverted back to using the keys. Changed to load variables through the keys json file